### PR TITLE
Use cwd to determine if we should install devDependencies

### DIFF
--- a/engine-dependencies.js
+++ b/engine-dependencies.js
@@ -1,6 +1,5 @@
 var semver = require("semver");
 var spawn = require("child_process").spawn;
-var findupNodeModules = require("findup-node-modules");
 var path = require("path");
 
 module.exports = engineDependencies;
@@ -12,30 +11,18 @@ var engineVersion = process.version;
 var app = engineVersion.substr(0, 3) === "v0." ? "node" : "iojs";
 var isWin = /^win/.test(process.platform);
 
-function engineDependencies(options, moduleName, callback){
-	if(typeof options === "string") {
-		moduleName = options;
-		options = undefined;
-	}
-	if(typeof moduleName === "function") {
-		callback = moduleName;
-		moduleName = undefined;
-	}
-
+function engineDependencies(options, callback){
 	// First see if we are in production
 	var installDevDependencies = process.env.NODE_ENV !== "production";
-	if(moduleName) {
-		// If we are inside a node_modules folder then do not install them.
-		installDevDependencies = !findupNodeModules(moduleName);
-		// We might be in the root folder for the project, check that
-		if(!installDevDependencies) {
-			installDevDependencies = path.dirname(process.cwd()) === moduleName;
-		}
+	if(installDevDependencies) {
+		// Make sure we are not inside of a node_modules folder
+		installDevDependencies = path.basename(path.dirname(process.cwd())) !==
+			"node_modules";
 	}
 
 	// Get the package.json engineDependencies
 	if(!options) {
-		var cwd = findupNodeModules(moduleName) || process.cwd();
+		var cwd = process.cwd();
 		var pkgJsonPath = path.join(cwd, "package.json");
 		var pkg = require(pkgJsonPath);
 		options = pkg.engineDependencies;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "findup-node-modules": "^0.1.1",
     "semver": "^5.0.1"
   }
 }


### PR DESCRIPTION
If we are inside a `node_modules` folder we shouldn't install
devDependencies
