### PR TITLE
Make work with Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - 0.10
   - 0.12
   - "iojs"
+  - "node"
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
-﻿# Test against this version of Node.js
+# Test against this version of Node.js
 environment:
   matrix:
   # node.js
   - nodejs_version: "0.10"
   - nodejs_version: "0.12"
+  - nodejs_version: "4.0.0"
   # io.js
   # - nodejs_version: "1.0"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
+  - npm config set registry "http://registry.npmjs.org"
   - npm install
 
 # Post-install test scripts.

--- a/engine-dependencies.js
+++ b/engine-dependencies.js
@@ -8,7 +8,8 @@ var apps = { node: true, iojs: true };
 var depTypes = { dependencies: true, devDependencies: true };
 
 var engineVersion = process.version;
-var app = engineVersion.substr(0, 3) === "v0." ? "node" : "iojs";
+var app = engineVersion.substr(0, 3) === "v0." ? "node" :
+	+engineVersion[1] >= 4 ? "node" : "iojs";
 var isWin = /^win/.test(process.platform);
 
 function engineDependencies(options, callback){

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,8 @@ var engineDependencies = require("../engine-dependencies");
 var assert = require("assert");
 
 var engineVersion = process.version;
-var app = engineVersion.substr(0, 3) === "v0." ? "node" : "iojs";
+var app = engineVersion.substr(0, 3) === "v0." ? "node" :
+	+engineVersion[1] >= 4 ? "node" : "iojs";
 var engineMajor = engineVersion.substr(0, 5);
 
 describe("Install dependency version based on engine used", function(){
@@ -16,6 +17,8 @@ describe("Install dependency version based on engine used", function(){
 			jqueryVersion = "1.11.2";
 		} else if(engineMajor === "v0.10") {
 			jqueryVersion = "1.11.0";
+		} else if(engineMajor === "v4.0.") {
+			jqueryVersion = "2.1.4";
 		}
 
 
@@ -28,6 +31,9 @@ describe("Install dependency version based on engine used", function(){
 				},
 				"0.12.x": {
 					"jquery": "1.11.2"
+				},
+				"^4.0.0": {
+					"jquery": "2.1.4"
 				}
 			},
 			"iojs": {


### PR DESCRIPTION
This updates engine dependencies so it properly considers engine
versions >= 4 to be Node and looks in the appropriate part of the
package.
